### PR TITLE
Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ __py*
 # *.[oa]
 # *~
 linux*
+darwin*
 lnInclude
 *.dep
 *.swp

--- a/Allwclean
+++ b/Allwclean
@@ -14,7 +14,7 @@ then
     sourceDir=foam-extend-$WM_PROJECT_VERSION
 elif [ "$WM_PROJECT" == "OpenFOAM" ];
 then
-    sourceDir=OpenFOAM-$WM_PROJECT_VERSION
+    sourceDir=OpenFOAM-${WM_PROJECT_VERSION/\.x/\.0}
 fi
 
 #Compile the correct isoAdvector version

--- a/Allwmake
+++ b/Allwmake
@@ -31,7 +31,7 @@ then
     sourceDir=foam-extend-$WM_PROJECT_VERSION
 elif [ "$WM_PROJECT" == "OpenFOAM" ];
 then
-    sourceDir=OpenFOAM-$WM_PROJECT_VERSION
+    sourceDir=OpenFOAM-${WM_PROJECT_VERSION/\.x/\.0}
 fi
 
 #Compile the correct isoAdvector version

--- a/applications/OpenFOAM-2.2.0/solvers/interFlow/Make/options
+++ b/applications/OpenFOAM-2.2.0/solvers/interFlow/Make/options
@@ -9,10 +9,13 @@ EXE_INC = $(ISODBUG) \
     -I$(LIB_SRC)/fvOptions/lnInclude \
     -I$(LIB_SRC)/sampling/lnInclude
 
+ifneq ($(WM_PROJECT_VERSION),2.2.0)
+EXE_INC += -DINCOMPRESSIBLE_TWO_PHASE_MIXTURE -I$(LIB_SRC)/transportModels/twoPhaseMixture/lnInclude
+endif
+
 EXE_LIBS = \
     -L$(FOAM_USER_LIBBIN) \
     -linterfaceProperties \
-    -ltwoPhaseInterfaceProperties \
     -lincompressibleTransportModels \
     -lincompressibleTurbulenceModel \
     -lincompressibleRASModels \
@@ -22,3 +25,9 @@ EXE_LIBS = \
     -lfvOptions \
     -lsampling \
     -lisoAdvection
+
+ifneq ($(WM_PROJECT_VERSION),2.2.0)
+EXE_LIBS += -ltwoPhaseProperties -ltwoPhaseMixture
+else
+EXE_LIBS += -ltwoPhaseInterfaceProperties
+endif

--- a/applications/OpenFOAM-2.2.0/solvers/interFlow/createFields.H
+++ b/applications/OpenFOAM-2.2.0/solvers/interFlow/createFields.H
@@ -30,7 +30,11 @@
 
 
     Info<< "Reading transportProperties\n" << endl;
+#ifdef INCOMPRESSIBLE_TWO_PHASE_MIXTURE
+    incompressibleTwoPhaseMixture twoPhaseProperties(U, phi);
+#else
     twoPhaseMixture twoPhaseProperties(U, phi);
+#endif
 
     volScalarField& alpha1(twoPhaseProperties.alpha1());
 

--- a/applications/OpenFOAM-2.2.0/solvers/interFlow/interFlow.C
+++ b/applications/OpenFOAM-2.2.0/solvers/interFlow/interFlow.C
@@ -43,7 +43,11 @@ Author
 #include "MULES.H"
 #include "subCycle.H"
 #include "interfaceProperties.H"
-#include "twoPhaseMixture.H"
+#ifdef INCOMPRESSIBLE_TWO_PHASE_MIXTURE
+#   include "incompressibleTwoPhaseMixture.H"
+#else
+#   include "twoPhaseMixture.H"
+#endif
 #include "turbulenceModel.H"
 #include "pimpleControl.H"
 #include "fvIOoptionList.H"
@@ -73,7 +77,7 @@ int main(int argc, char *argv[])
     Info<< "\nStarting time loop\n" << endl;
     scalar executionTime = runTime.elapsedCpuTime();
     scalar advectionTime = 0;
-    
+
     while (runTime.run())
     {
         #include "readTimeControls.H"
@@ -91,7 +95,7 @@ int main(int argc, char *argv[])
 
         //Advance alpha1 from time t to t+dt
         advector.advect();
-        
+
         if (printSurfCells)
         {
             advector.getSurfaceCells(surfCells);
@@ -100,8 +104,8 @@ int main(int argc, char *argv[])
         {
             advector.getBoundedCells(boundCells);
         }
-        
-        Info << "1-max(alpha1) = " << 1-gMax(alpha1.internalField()) 
+
+        Info << "1-max(alpha1) = " << 1-gMax(alpha1.internalField())
             << " and min(alpha1) = " << gMin(alpha1.internalField()) << endl;
 
         //Clip and snap alpha1 to ensure strict boundedness to machine precision
@@ -116,12 +120,12 @@ int main(int argc, char *argv[])
 
         rho == alpha1*rho1 + (scalar(1) - alpha1)*rho2;
         rhoPhi = advector.getRhoPhi(rho1, rho2);
-        
+
 //        #include "alphaEqnSubCycle.H"
         interface.correct();
 
         advectionTime += (runTime.elapsedCpuTime() - advectionStartTime);
-        
+
         // --- Pressure-velocity PIMPLE corrector loop
         while (pimple.loop())
         {

--- a/applications/OpenFOAM-2.2.0/solvers/mulesFoam/Make/options
+++ b/applications/OpenFOAM-2.2.0/solvers/mulesFoam/Make/options
@@ -8,9 +8,12 @@ EXE_INC = \
     -I$(LIB_SRC)/fvOptions/lnInclude \
     -I$(LIB_SRC)/sampling/lnInclude
 
+ifneq ($(WM_PROJECT_VERSION),2.2.0)
+EXE_INC += -DINCOMPRESSIBLE_TWO_PHASE_MIXTURE -I$(LIB_SRC)/transportModels/twoPhaseMixture/lnInclude
+endif
+
 EXE_LIBS = \
     -linterfaceProperties \
-    -ltwoPhaseInterfaceProperties \
     -lincompressibleTransportModels \
     -lincompressibleTurbulenceModel \
     -lincompressibleRASModels \
@@ -19,3 +22,9 @@ EXE_LIBS = \
     -lmeshTools \
     -lfvOptions \
     -lsampling
+
+ifneq ($(WM_PROJECT_VERSION),2.2.0)
+EXE_LIBS += -ltwoPhaseProperties -ltwoPhaseMixture
+else
+EXE_LIBS += -ltwoPhaseInterfaceProperties
+endif

--- a/applications/OpenFOAM-2.2.0/solvers/mulesFoam/createFields.H
+++ b/applications/OpenFOAM-2.2.0/solvers/mulesFoam/createFields.H
@@ -30,7 +30,11 @@
 
 
     Info<< "Reading transportProperties\n" << endl;
+#ifdef INCOMPRESSIBLE_TWO_PHASE_MIXTURE
+    incompressibleTwoPhaseMixture twoPhaseProperties(U, phi);
+#else
     twoPhaseMixture twoPhaseProperties(U, phi);
+#endif
 
     volScalarField& alpha1(twoPhaseProperties.alpha1());
 

--- a/applications/OpenFOAM-2.2.0/solvers/mulesFoam/mulesFoam.C
+++ b/applications/OpenFOAM-2.2.0/solvers/mulesFoam/mulesFoam.C
@@ -22,9 +22,9 @@ Application
 
 Description
     This solver is just interFoam taking a number of extra input paramters.
-	The sole purpose of the solver is to compare the behaviour of MULES for 
+	The sole purpose of the solver is to compare the behaviour of MULES for
 	pure advection problems with the corresponding IsoAdvector results.
-	
+
 Author
     Johan Roenby, DHI, all rights reserved
 
@@ -34,7 +34,11 @@ Author
 #include "MULES.H"
 #include "subCycle.H"
 #include "interfaceProperties.H"
-#include "twoPhaseMixture.H"
+#ifdef INCOMPRESSIBLE_TWO_PHASE_MIXTURE
+#   include "incompressibleTwoPhaseMixture.H"
+#else
+#   include "twoPhaseMixture.H"
+#endif
 #include "turbulenceModel.H"
 #include "pimpleControl.H"
 #include "fvIOoptionList.H"
@@ -82,7 +86,7 @@ int main(int argc, char *argv[])
 		if ( period > 0.0 )
 		{
 			phi = phi0*Foam::cos(2.0*M_PI*(t + 0.5*dt)/period);
-			U = U0*Foam::cos(2.0*M_PI*(t + 0.5*dt)/period);		
+			U = U0*Foam::cos(2.0*M_PI*(t + 0.5*dt)/period);
 		}
 
         runTime++;

--- a/applications/OpenFOAM-2.2.0/utilities/postProcessing/uniFlowErrors/uniFlowErrors.C
+++ b/applications/OpenFOAM-2.2.0/utilities/postProcessing/uniFlowErrors/uniFlowErrors.C
@@ -21,7 +21,7 @@ Application
     uniFlowErrors
 
 Description
-    Calculate discrepancy from exact VOF solution for a plane, cylinder or 
+    Calculate discrepancy from exact VOF solution for a plane, cylinder or
 	sphere in a uniform velocity field.
 
 Author
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
     #include "readTimeControls.H"
 	instantList instList = runTime.times();
 	//Setting time to first time which is not 'constant'
-	runTime.setTime(instList[1],0); 	
+	runTime.setTime(instList[1],0);
     Foam::fvMesh mesh
     (
         Foam::IOobject
@@ -59,10 +59,10 @@ int main(int argc, char *argv[])
             Foam::IOobject::MUST_READ
         )
     );
-	
+
 //	scalar delta0 = Foam::pow(sum(mesh.V()).value(),1.0/3.0);
 //	Info << "Average edge lengt = " << delta0 << endl;
-	
+
 //	Info<< "Reading field alpha1\n" << endl;
 	volScalarField alpha1
 	(
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
 	);
 	scalar V0 = sum(mesh.V()*alpha1).value();
 	Info << "Initial water volume V0 = " << V0 << endl;
-	
+
 //	Info<< "Reading field U\n" << endl;
     volVectorField U
     (
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
 	Info << "Velocity U0 = " << U0 << endl;
 
     volScalarField alpha1Exact = alpha1; //Values are overwritten
-	
+
 //	Info<< "Reading isoSurfDict\n" << endl;
 	IOdictionary isoSurfDict
 	(
@@ -116,9 +116,9 @@ int main(int argc, char *argv[])
 	const vector direction = isoSurfDict.lookupOrDefault<vector>("direction",vector::zero);
 	const scalar radius = isoSurfDict.lookupOrDefault<scalar>("radius",0.0);
 
-	const scalarField x = mesh.points().component(0);
-    const scalarField y = mesh.points().component(1);
-    const scalarField z = mesh.points().component(2);
+	const scalarField x(mesh.points().component(0));
+    const scalarField y(mesh.points().component(1));
+    const scalarField z(mesh.points().component(2));
     scalar f0 = 0.0;
 	scalarField f(x.size());
 
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
 			),
 			mesh
 		);
-		
+
 		vector centre = centre0 + U0*runTime.time().value();
 		if ( surfType == "plane" )
 		{
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
         if (mag(U0*runTime.time().value()) < 1e-10)
         {
             Info << "Reading exact alpha1 from 0 directory." << endl;
-            volScalarField dummy 
+            volScalarField dummy
             (
                 IOobject
                 (
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
                 ),
                 mesh
             );
-            alpha1Exact = dummy;            
+            alpha1Exact = dummy;
         }
         else
         {
@@ -192,37 +192,37 @@ int main(int argc, char *argv[])
 		scalar E1 = sum(mag(alpha1Exact-alpha1)*mesh.V());
 		vector cmExact = (sum(alpha1Exact*mesh.V()*mesh.C())/sum(mesh.V())).value();
 		vector cm = (sum(alpha1*mesh.V()*mesh.C())/sum(mesh.V())).value();
-		
+
         isoCutCell icc(mesh, f);
         icc.VolumeOfFluid(alpha1Exact, f0);
-        
+
         volPointInterpolation vpi(mesh);
 		scalarField ap = vpi.interpolate(alpha1);
         isoCutCell icc2(mesh, ap);
-		
+
 		//Volume if alpha = 0.1 isosurface for calculated solution
         volScalarField alpha101 = alpha1;
-		icc2.VolumeOfFluid(alpha101, .01);	
+		icc2.VolumeOfFluid(alpha101, .01);
 		scalar V01 = sum(mesh.V()*alpha101).value();
 
-		//Volume if alpha = .99 isosurface for calculated solution		
+		//Volume if alpha = .99 isosurface for calculated solution
         volScalarField alpha199 = alpha1;
-		icc2.VolumeOfFluid(alpha199, .99);	
+		icc2.VolumeOfFluid(alpha199, .99);
 		scalar V99 = sum(mesh.V()*alpha199).value();
 
 		scalarField apExact = vpi.interpolate(alpha1Exact);
         isoCutCell icc3(mesh, apExact);
-		
+
 		//Volume if alpha = 0.1 isosurface for exact solution
         volScalarField alpha1Exact01 = alpha1;
-		icc3.VolumeOfFluid(alpha1Exact01, .01);	
+		icc3.VolumeOfFluid(alpha1Exact01, .01);
 		scalar V01Exact = sum(mesh.V()*alpha1Exact01).value();
 
-		//Volume if alpha = .99 isosurface for exact solution		
+		//Volume if alpha = .99 isosurface for exact solution
         volScalarField alpha1Exact99 = alpha1; //Convenience copy: values are overwritten in next line
-		icc3.VolumeOfFluid(alpha1Exact99, .99);	
+		icc3.VolumeOfFluid(alpha1Exact99, .99);
 		scalar V99Exact = sum(mesh.V()*alpha1Exact99).value();
-		
+
 //		scalar PI = Foam::constant::mathematical::pi;
 //		scalar delta = Foam::pow(3.0/(4.0*PI)*V01,1.0/3.0) - Foam::pow(3.0/(4.0*PI)*V99,1.0/3.0);
 //		scalar deltaExact = Foam::pow(3.0/(4.0*PI)*V01Exact,1.0/3.0) - Foam::pow(3.0/(4.0*PI)*V99Exact,1.0/3.0);
@@ -230,17 +230,17 @@ int main(int argc, char *argv[])
 		scalar dV = V01 - V99;
 
 		Info << "Time: " << runTime.time().value() << endl;
-		 
-        int w = 9;	
+
+        int w = 9;
 //		cout << "E1 "
-		cout << setw(w) << "E1/V0     " 
-			 << setw(w) << "dVrel     " 
-			 << setw(w) << "aMin      " 
-			 << setw(w) << "1-aMax    " 
-			 << setw(w) << "dWrel     " 
-//			 << "dW " 
+		cout << setw(w) << "E1/V0     "
+			 << setw(w) << "dVrel     "
+			 << setw(w) << "aMin      "
+			 << setw(w) << "1-aMax    "
+			 << setw(w) << "dWrel     "
+//			 << "dW "
 //			 << "dWEx "
-//			 << "dCM" 
+//			 << "dCM"
             << endl;
 
 //		cout << setprecision(2) << E1 << " "
@@ -251,12 +251,12 @@ int main(int argc, char *argv[])
 			 << setw(w) << setprecision(2) << (dV-dVExact)/(dVExact+SMALL) << " "
 //			 << setprecision(2) << dV << " "
 //			 << setprecision(2) << dVExact << " "
-//		     << setprecision(2) << mag(cm-cmExact) 
+//		     << setprecision(2) << mag(cm-cmExact)
              << endl;
-			 
+
 //			<< ",\td_Ex/d0 = " << deltaExact/delta0 << endl;
 //			<< ",\t(V01-Ex)/Ex = " << (V01-V01Exact)/V01Exact
-//			<< ",\t(V99-Ex)/Ex = " << (V99-V99Exact)/V99Exact << endl;		 
+//			<< ",\t(V99-Ex)/Ex = " << (V99-V99Exact)/V99Exact << endl;
 	}
 
     return 0;

--- a/applications/OpenFOAM-2.2.0/utilities/preProcessing/isoSurf/isoSurf.C
+++ b/applications/OpenFOAM-2.2.0/utilities/preProcessing/isoSurf/isoSurf.C
@@ -21,7 +21,7 @@ Application
     isoSurf
 
 Description
-    Uses isoCutter to create a volume fraction field from either a cylinder, 
+    Uses isoCutter to create a volume fraction field from either a cylinder,
     a sphere or a plane.
 
 Author
@@ -74,9 +74,9 @@ int main(int argc, char *argv[])
 	const vector direction = isoSurfDict.lookupOrDefault<vector>("direction",vector::zero);
 	const scalar radius = isoSurfDict.lookupOrDefault<scalar>("radius",0.0);
 
-	const scalarField x = mesh.points().component(0);
-    const scalarField y = mesh.points().component(1);
-    const scalarField z = mesh.points().component(2);
+	const scalarField x(mesh.points().component(0));
+    const scalarField y(mesh.points().component(1));
+    const scalarField z(mesh.points().component(2));
     scalar f0 = 0.0;
 	scalarField f(x.size());
 
@@ -100,8 +100,8 @@ int main(int argc, char *argv[])
         const scalar lambda = isoSurfDict.lookupOrDefault<scalar>("lambda",1);
         const scalar amplitude = isoSurfDict.lookupOrDefault<scalar>("amplitude",.1);
         const vector up = isoSurfDict.lookupOrDefault<vector>("up",vector::zero);
-        const scalarField xx = (mesh.points()-centre) & direction/mag(direction);
-        const scalarField zz = (mesh.points()-centre) & up/mag(up);
+        const scalarField xx((mesh.points()-centre) & direction/mag(direction));
+        const scalarField zz((mesh.points()-centre) & up/mag(up));
 		f = amplitude*Foam::sin(2*M_PI*xx/lambda) - zz;
 		f0 = 0;
 	}
@@ -111,24 +111,24 @@ int main(int argc, char *argv[])
 		Info << "Aborting..." << endl;
 	}
 
-    
+
     Info << "surfType = " << surfType << endl;
 
     //Define function on mesh points and isovalue
-	
+
 	//Calculating alpha1 volScalarField from f = f0 isosurface
     isoCutCell icc(mesh,f);
     icc.VolumeOfFluid(alpha1, f0);
-	
+
 	ISstream::defaultPrecision(18);
-	
+
     alpha1.write(); //Writing volScalarField alpha1
 
     const scalarField& alpha = alpha1.internalField();
 	Info << "sum(alpha*V) = " << gSum(mesh.V()*alpha)
 	 << ", 1-max(alpha1) = " << 1 - gMax(alpha)
 	 << "\t min(alpha1) = " << gMin(alpha) << endl;
-	
+
     Info<< "End\n" << endl;
 
     return 0;

--- a/applications/OpenFOAM-4.0/utilities/postProcessing/uniFlowErrors/uniFlowErrors.C
+++ b/applications/OpenFOAM-4.0/utilities/postProcessing/uniFlowErrors/uniFlowErrors.C
@@ -21,7 +21,7 @@ Application
     uniFlowErrors
 
 Description
-    Calculate discrepancy from exact VOF solution for a plane, cylinder or 
+    Calculate discrepancy from exact VOF solution for a plane, cylinder or
 	sphere in a uniform velocity field.
 
 Author
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
 //    #include "readTimeControls.H"
 	instantList instList = runTime.times();
 	//Setting time to first time which is not 'constant'
-	runTime.setTime(instList[1],0); 	
+	runTime.setTime(instList[1],0);
     Foam::fvMesh mesh
     (
         Foam::IOobject
@@ -59,10 +59,10 @@ int main(int argc, char *argv[])
             Foam::IOobject::MUST_READ
         )
     );
-	
+
 //	scalar delta0 = Foam::pow(sum(mesh.V()).value(),1.0/3.0);
 //	Info << "Average edge lengt = " << delta0 << endl;
-	
+
 //	Info<< "Reading field alpha1\n" << endl;
 	volScalarField alpha1
 	(
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
 	);
 	scalar V0 = sum(mesh.V()*alpha1).value();
 	Info << "Initial water volume V0 = " << V0 << endl;
-	
+
 //	Info<< "Reading field U\n" << endl;
     volVectorField U
     (
@@ -97,7 +97,7 @@ int main(int argc, char *argv[])
 	Info << "Velocity U0 = " << U0 << endl;
 
     volScalarField alpha1Exact = alpha1; //Values are overwritten
-	
+
 //	Info<< "Reading isoSurfDict\n" << endl;
 	IOdictionary isoSurfDict
 	(
@@ -116,9 +116,9 @@ int main(int argc, char *argv[])
 	const Foam::vector direction = isoSurfDict.lookupOrDefault<Foam::vector>("direction",Foam::vector::zero);
 	const scalar radius = isoSurfDict.lookupOrDefault<scalar>("radius",0.0);
 
-	const scalarField x = mesh.points().component(0);
-    const scalarField y = mesh.points().component(1);
-    const scalarField z = mesh.points().component(2);
+	const scalarField x(mesh.points().component(0));
+    const scalarField y(mesh.points().component(1));
+    const scalarField z(mesh.points().component(2));
     scalar f0 = 0.0;
 	scalarField f(x.size());
 
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
 			),
 			mesh
 		);
-		
+
 		Foam::vector centre = centre0 + U0*runTime.time().value();
 		if ( surfType == "plane" )
 		{
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
         if (mag(U0*runTime.time().value()) < 1e-10)
         {
             Info << "Reading exact alpha1 from 0 directory." << endl;
-            volScalarField dummy 
+            volScalarField dummy
             (
                 IOobject
                 (
@@ -179,7 +179,7 @@ int main(int argc, char *argv[])
                 ),
                 mesh
             );
-            alpha1Exact = dummy;            
+            alpha1Exact = dummy;
         }
         else
         {
@@ -192,37 +192,37 @@ int main(int argc, char *argv[])
 		scalar E1 = sum(mag(alpha1Exact-alpha1)*mesh.V());
 		Foam::vector cmExact = (sum(alpha1Exact*mesh.V()*mesh.C())/sum(mesh.V())).value();
 		Foam::vector cm = (sum(alpha1*mesh.V()*mesh.C())/sum(mesh.V())).value();
-		
+
         isoCutCell icc(mesh, f);
         icc.VolumeOfFluid(alpha1Exact, f0);
-        
+
         volPointInterpolation vpi(mesh);
 		scalarField ap = vpi.interpolate(alpha1);
         isoCutCell icc2(mesh, ap);
-		
+
 		//Volume if alpha = 0.1 isosurface for calculated solution
         volScalarField alpha101 = alpha1;
-		icc2.VolumeOfFluid(alpha101, .01);	
+		icc2.VolumeOfFluid(alpha101, .01);
 		scalar V01 = sum(mesh.V()*alpha101).value();
 
-		//Volume if alpha = .99 isosurface for calculated solution		
+		//Volume if alpha = .99 isosurface for calculated solution
         volScalarField alpha199 = alpha1;
-		icc2.VolumeOfFluid(alpha199, .99);	
+		icc2.VolumeOfFluid(alpha199, .99);
 		scalar V99 = sum(mesh.V()*alpha199).value();
 
 		scalarField apExact = vpi.interpolate(alpha1Exact);
         isoCutCell icc3(mesh, apExact);
-		
+
 		//Volume if alpha = 0.1 isosurface for exact solution
         volScalarField alpha1Exact01 = alpha1;
-		icc3.VolumeOfFluid(alpha1Exact01, .01);	
+		icc3.VolumeOfFluid(alpha1Exact01, .01);
 		scalar V01Exact = sum(mesh.V()*alpha1Exact01).value();
 
-		//Volume if alpha = .99 isosurface for exact solution		
+		//Volume if alpha = .99 isosurface for exact solution
         volScalarField alpha1Exact99 = alpha1; //Convenience copy: values are overwritten in next line
-		icc3.VolumeOfFluid(alpha1Exact99, .99);	
+		icc3.VolumeOfFluid(alpha1Exact99, .99);
 		scalar V99Exact = sum(mesh.V()*alpha1Exact99).value();
-		
+
 //		scalar PI = Foam::constant::mathematical::pi;
 //		scalar delta = Foam::pow(3.0/(4.0*PI)*V01,1.0/3.0) - Foam::pow(3.0/(4.0*PI)*V99,1.0/3.0);
 //		scalar deltaExact = Foam::pow(3.0/(4.0*PI)*V01Exact,1.0/3.0) - Foam::pow(3.0/(4.0*PI)*V99Exact,1.0/3.0);
@@ -230,17 +230,17 @@ int main(int argc, char *argv[])
 		scalar dV = V01 - V99;
 
 		Info << "Time: " << runTime.time().value() << endl;
-		 
-        int w = 9;	
+
+        int w = 9;
 //		cout << "E1 "
-		cout << setw(w) << "E1/V0     " 
-			 << setw(w) << "dVrel     " 
-			 << setw(w) << "aMin      " 
-			 << setw(w) << "1-aMax    " 
-			 << setw(w) << "dWrel     " 
-//			 << "dW " 
+		cout << setw(w) << "E1/V0     "
+			 << setw(w) << "dVrel     "
+			 << setw(w) << "aMin      "
+			 << setw(w) << "1-aMax    "
+			 << setw(w) << "dWrel     "
+//			 << "dW "
 //			 << "dWEx "
-//			 << "dCM" 
+//			 << "dCM"
             << endl;
 
 //		cout << setprecision(2) << E1 << " "
@@ -251,12 +251,12 @@ int main(int argc, char *argv[])
 			 << setw(w) << setprecision(2) << (dV-dVExact)/(dVExact+SMALL) << " "
 //			 << setprecision(2) << dV << " "
 //			 << setprecision(2) << dVExact << " "
-//		     << setprecision(2) << mag(cm-cmExact) 
+//		     << setprecision(2) << mag(cm-cmExact)
              << endl;
-			 
+
 //			<< ",\td_Ex/d0 = " << deltaExact/delta0 << endl;
 //			<< ",\t(V01-Ex)/Ex = " << (V01-V01Exact)/V01Exact
-//			<< ",\t(V99-Ex)/Ex = " << (V99-V99Exact)/V99Exact << endl;		 
+//			<< ",\t(V99-Ex)/Ex = " << (V99-V99Exact)/V99Exact << endl;
 	}
 
     return 0;

--- a/applications/OpenFOAM-4.0/utilities/preProcessing/isoSurf/isoSurf.C
+++ b/applications/OpenFOAM-4.0/utilities/preProcessing/isoSurf/isoSurf.C
@@ -21,7 +21,7 @@ Application
     isoSurf
 
 Description
-    Uses isoCutter to create a volume fraction field from either a cylinder, 
+    Uses isoCutter to create a volume fraction field from either a cylinder,
     a sphere or a plane.
 
 Author
@@ -74,9 +74,9 @@ int main(int argc, char *argv[])
 	const vector direction = isoSurfDict.lookupOrDefault<vector>("direction",vector::zero);
 	const scalar radius = isoSurfDict.lookupOrDefault<scalar>("radius",0.0);
 
-	const scalarField x = mesh.points().component(0);
-    const scalarField y = mesh.points().component(1);
-    const scalarField z = mesh.points().component(2);
+	const scalarField x(mesh.points().component(0));
+    const scalarField y(mesh.points().component(1));
+    const scalarField z(mesh.points().component(2));
     scalar f0 = 0.0;
 	scalarField f(x.size());
 
@@ -100,8 +100,8 @@ int main(int argc, char *argv[])
         const scalar lambda = isoSurfDict.lookupOrDefault<scalar>("lambda",1);
         const scalar amplitude = isoSurfDict.lookupOrDefault<scalar>("amplitude",.1);
         const vector up = isoSurfDict.lookupOrDefault<vector>("up",vector::zero);
-        const scalarField xx = (mesh.points()-centre) & direction/mag(direction);
-        const scalarField zz = (mesh.points()-centre) & up/mag(up);
+        const scalarField xx((mesh.points()-centre) & direction/mag(direction));
+        const scalarField zz((mesh.points()-centre) & up/mag(up));
 		f = amplitude*Foam::sin(2*M_PI*xx/lambda) - zz;
 		f0 = 0;
 	}
@@ -111,24 +111,24 @@ int main(int argc, char *argv[])
 		Info << "Aborting..." << endl;
 	}
 
-    
+
     Info << "surfType = " << surfType << endl;
 
     //Define function on mesh points and isovalue
-	
+
 	//Calculating alpha1 volScalarField from f = f0 isosurface
     isoCutCell icc(mesh,f);
     icc.VolumeOfFluid(alpha1, f0);
-	
+
 	ISstream::defaultPrecision(18);
-	
+
     alpha1.write(); //Writing volScalarField alpha1
 
     const scalarField& alpha = alpha1.internalField();
 	Info << "sum(alpha*V) = " << gSum(mesh.V()*alpha)
 	 << ", 1-max(alpha1) = " << 1 - gMax(alpha)
 	 << "\t min(alpha1) = " << gMin(alpha) << endl;
-	
+
     Info<< "End\n" << endl;
 
     return 0;

--- a/run/interFlow/damBreak/Allrun
+++ b/run/interFlow/damBreak/Allrun
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-application=$(sed -ne "s/^application\s*\(.*\);/\1/p" system/controlDict)
+application=$(sed -E -n "s%^application[[:space:]]+([^[:space:]]+);%\1%p" system/controlDict)
 
 cp -r 0.org 0
 
@@ -9,4 +9,11 @@ mkdir logs
 blockMesh > logs/blockMesh.log 2>&1
 setFields > logs/setFields.log 2>&1
 
-$application > logs/${application}.log 2>&1
+if [ -n "$application" ]
+then
+    $application > logs/${application}.log 2>&1
+else
+    echo
+    echo "Can not get application name to run. Exiting."
+    echo
+fi

--- a/run/interFlow/standingWave/Allclean
+++ b/run/interFlow/standingWave/Allclean
@@ -3,4 +3,4 @@
 rm -rf [0-9] *.[0-9]* [0-9][0-9] [0-9][0-9].[0-9]* 
 rm -rf log* proc*
 rm -rf constant/polyMesh/{neighbour,owner,faces,points,boundary,sets,*Zones} 
-rm system/{refineMeshDict,cellSetDict} constant/transportProperties
+rm -f system/{refineMeshDict,cellSetDict} constant/transportProperties

--- a/run/interFlow/standingWave/Allrun
+++ b/run/interFlow/standingWave/Allrun
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-nProc=$(sed -ne "s/^numberOfSubdomains *\(.*\);/\1/p" system/decomposeParDict)
-application=$(sed -ne "s/^application *\(.*\);/\1/p" system/controlDict)
+nProc=$(sed -E -n "s%^numberOfSubdomains[[:space:]]+([^[:space:]]+);%\1%p" system/decomposeParDict)
+application=$(sed -E -n "s%^application[[:space:]]+([^[:space:]]+);%\1%p" system/controlDict)
 jobStart=$(date +"%Y%m%d%H%M")
 
 if [ ! -d "logs" ]; then
@@ -36,14 +36,15 @@ if [ ! -d "logs" ]; then
         refineMesh -dict constant/polyMesh/refineMeshDict2 -overwrite > logs/refineMeshDict2.log 2>&1
 
         isoSurf > logs/isoSurf.log 2>&1
-        
-        OFvers=$(echo $WM_PROJECT_VERSION | cut -c1-3)
+
+        OFvers=$(echo ${WM_PROJECT_VERSION/\.x/} | cut -c1-3)
         newVersion=$(echo "$OFvers>2.2" | bc)
-        if [ $newVersion -eq 1 ];
+        if [ "x$newVersion" = "x1" ];
         then
             cp constant/transportProperties.new constant/transportProperties
             mv 0/alpha1 0/alpha.water
-            sed -i 's/alpha1/alpha.water/g' 0/alpha.water
+            sed -i~ 's/alpha1/alpha.water/g' 0/alpha.water
+            rm -f 0/alpha.water~
         else
             cp constant/transportProperties.old constant/transportProperties
         fi
@@ -54,12 +55,19 @@ else
     mkdir logs
 fi
 
-if [ "$nProc" -gt "1" ];
+if [ -n "$application" ]
 then
-    if [ ! -d "processor0" ]; then
-                decomposePar > logs/decomposePar.log 2>&1
+    if [ "$nProc" -gt "1" ];
+    then
+        if [ ! -d "processor0" ]; then
+            decomposePar > logs/decomposePar.log 2>&1
+        fi
+        mpirun -np $nProc $application -parallel > logs/$application.log 2>&1
+    else
+        $application > logs/$application.log 2>&1
     fi
-    mpirun -np $nProc $application -parallel > logs/$application.log 2>&1
 else
-    $application > logs/$application.log 2>&1
+    echo
+    echo "Can not get application to run. Exiting."
+    echo
 fi

--- a/run/interFlow/tiltedBox/Allrun
+++ b/run/interFlow/tiltedBox/Allrun
@@ -1,9 +1,13 @@
 #!/bin/sh
 
-application=$(sed -ne "s/^application *\(.*\);/\1/p" system/controlDict)
+application=$(sed -E -n "s%^application[[:space:]]+([^[:space:]]+);%\1%p" system/controlDict)
+
 
 mkdir logs
 
-$application > logs/${application}.log 2>&1
+if [ -n "$application" ]
+then
+    $application > logs/${application}.log 2>&1
 
-foamToVTK -surfaceFields
+    foamToVTK -surfaceFields
+fi

--- a/run/isoAdvector/discInUniFlow/baseCase/Allrun
+++ b/run/isoAdvector/discInUniFlow/baseCase/Allrun
@@ -1,20 +1,22 @@
 #!/bin/sh
 
-application=$(sed -ne "s/^application\s*\(.*\);/\1/p" system/controlDict)
+application=$(sed -E -n "s%^application[[:space:]]+([^[:space:]]+);%\1%p" system/controlDict)
 
 mkdir -p logs
 
-if [ ! -d "0" ];
-then
-    cp -r 0.org 0
-fi
+[ -d "0" ] || cp -r 0.org 0
 
-if [ ! -f "constant/polyMesh/owner" ];
-then
-    blockMesh > logs/blockMesh.log 2>&1
-fi
+[ -f "constant/polyMesh/owner" ] \
+    || blockMesh > logs/blockMesh.log 2>&1
 
 isoSurf > logs/isoSurf.log 2>&1
 
-$application > logs/${application}.log 2>&1
+if [ -n "$application" ]
+then
+    $application > logs/${application}.log 2>&1
+else
+    echo
+    echo "Can not find application. Exiting."
+    echo
+fi
 

--- a/run/isoAdvector/notchedDisc/baseCase/Allrun
+++ b/run/isoAdvector/notchedDisc/baseCase/Allrun
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-application=$(sed -ne "s/^application\s*\(.*\);/\1/p" system/controlDict)
+application=$(sed -E -n "s%^application[[:space:]]+([^[:space:]]+);%\1%p" system/controlDict)
 jobStart=$(date +"%Y_%m_%d_%H_%M")
 
 if [ ! -d "logs" ]; then
@@ -25,4 +25,11 @@ cd ..
 generateU/generateU > logs/generateU.log 2>&1
 isoSurf > logs/isoSurf.log 2>&1
 setFields > logs/setFields.log 2>&1
-$application > logs/${application}.log 2>&1
+if [ -n "$application" ]
+then
+    $application > logs/${application}.log 2>&1
+else
+    echo
+    echo "Can not find application to run. Exiting."
+    echo
+fi

--- a/run/isoAdvector/sShapedFlow/Allrun
+++ b/run/isoAdvector/sShapedFlow/Allrun
@@ -3,7 +3,7 @@
 #./Allclean
 
 #nProc=$(sed -ne "s/^numberOfSubdomains *\(.*\);/\1/p" system/decomposeParDict)
-application=$(sed -ne "s/^application *\(.*\);/\1/p" system/controlDict)
+application=$(sed -E -n "s%^application[[:space:]]+([^[:space:]]+);%\1%p" system/controlDict)
 jobStart=$(date +"%Y%m%d%H%M")
 
 cd generateU
@@ -21,6 +21,12 @@ else
     mkdir logs
 fi
 
-
-$application > logs/${application}.log 2>&1
+if [ -n "$application" ]
+then
+    $application > logs/${application}.log 2>&1
+else
+    echo
+    echo "Can not get application name to run. Exiting."
+    echo
+fi
 

--- a/run/isoAdvector/shearFlow3D/baseCase/Allrun
+++ b/run/isoAdvector/shearFlow3D/baseCase/Allrun
@@ -3,7 +3,7 @@
 #./Allclean
 
 #nProc=$(sed -ne "s/^numberOfSubdomains *\(.*\);/\1/p" system/decomposeParDict)
-application=$(sed -ne "s/^application\s*\(.*\);/\1/p" system/controlDict)
+application=$(sed -E -n "s%^application[[:space:]]+([^[:space:]]+);%\1%p" system/controlDict)
 jobStart=$(date +"%Y%m%d%H%M")
 
 cd generateU
@@ -23,6 +23,11 @@ else
     mkdir logs
 fi
 
-
-$application > logs/${application}.log 2>&1
-
+if [ -n "$application" ]
+then
+    $application > logs/${application}.log 2>&1
+else
+    echo
+    echo "Can not get application name to run. Exiting."
+    echo
+fi

--- a/run/isoAdvector/smearedSphere/baseCase/Allrun
+++ b/run/isoAdvector/smearedSphere/baseCase/Allrun
@@ -3,7 +3,7 @@
 #./Allclean
 
 #nProc=$(sed -ne "s/^numberOfSubdomains *\(.*\);/\1/p" system/decomposeParDict)
-application=$(sed -ne "s/^application\s*\(.*\);/\1/p" system/controlDict)
+application=$(sed -E -n "s%^application[[:space:]]+([^[:space:]]+);%\1%p" system/controlDict)
 jobStart=$(date +"%Y%m%d%H%M")
 
 cd generateU
@@ -23,6 +23,11 @@ else
     mkdir logs
 fi
 
-
-$application > logs/${application}.log 2>&1
-
+if [ -n "$application" ]
+then
+    $application > logs/${application}.log 2>&1
+else
+    echo
+    echo "Can not get application name to run. Exiting."
+    echo
+fi

--- a/run/isoAdvector/sphereInUniFlow/baseCase/Allrun
+++ b/run/isoAdvector/sphereInUniFlow/baseCase/Allrun
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-application=$(sed -ne "s/^application\s*\(.*\);/\1/p" system/controlDict)
+application=$(sed -E -n "s%^application[[:space:]]+([^[:space:]]+);%\1%p" system/controlDict)
 jobStart=$(date +"%Y_%m_%d_%H_%M")
 
 if [ ! -d "logs" ];
@@ -22,4 +22,11 @@ fi
 
 isoSurf > logs/isoSurf.log 2>&1
 
-$application > logs/${application}.log 2>&1
+if [ -n "$application" ]
+then
+    $application > logs/${application}.log 2>&1
+else
+    echo
+    echo "Can not get application name to run. Exiting."
+    echo
+fi

--- a/run/isoAdvector/vortexShearedDisc/baseCase/Allrun
+++ b/run/isoAdvector/vortexShearedDisc/baseCase/Allrun
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-application=$(sed -ne "s/^application\s*\(.*\);/\1/p" system/controlDict)
+application=$(sed -E -n "s%^application[[:space:]]+([^[:space:]]+);%\1%p" system/controlDict)
 jobStart=$(date +"%Y_%m_%d_%H_%M")
 
 if [ ! -d "logs" ];
@@ -27,4 +27,11 @@ cd ..
 generateU/generateU > logs/generateU.log 2>&1
 isoSurf > logs/isoSurf.log 2>&1
 
-$application > logs/${application}.log 2>&1
+if [ -n "$application" ]
+then
+    $application > logs/${application}.log 2>&1
+else
+    echo
+    echo "Can not get application name to run. Exiting."
+    echo
+fi

--- a/run/isoCutTester/Allrun
+++ b/run/isoCutTester/Allrun
@@ -2,8 +2,8 @@
 
 #./Allclean
 
-nProc=$(sed -ne "s/^numberOfSubdomains *\(.*\);/\1/p" system/decomposeParDict)
-application=$(sed -ne "s/^application *\(.*\);/\1/p" system/controlDict)
+nProc=$(sed -E -n "s%^numberOfSubdomains[[:space:]]+([^[:space:]]+);%\1%p" system/decomposeParDict)
+application=$(sed -E -n "s%^application[[:space:]]+([^[:space:]]+);%\1%p" system/controlDict)
 jobStart=$(date +"%Y%m%d%H%M")
 
 if [ ! -d "logs" ]; then

--- a/src/OpenFOAM-2.2.0/finiteVolume/interpolationSchemes/CICSAM/CICSAM.C
+++ b/src/OpenFOAM-2.2.0/finiteVolume/interpolationSchemes/CICSAM/CICSAM.C
@@ -235,7 +235,7 @@ Foam::tmp<Foam::surfaceScalarField> Foam::CICSAM::limiter
     );
     surfaceScalarField& lim = tLimiter();
 
-    volVectorField gradc = fvc::grad(phi);
+    volVectorField gradc(fvc::grad(phi));
 
 /*
     surfaceScalarField Cof =
@@ -246,12 +246,14 @@ Foam::tmp<Foam::surfaceScalarField> Foam::CICSAM::limiter
         );
 */
 
-    surfaceScalarField Cof =
+    surfaceScalarField Cof
+    (
         0.5 * mesh.time().deltaT()
         *upwind<scalar>(mesh, faceFlux_).interpolate
         (
             fvc::surfaceIntegrate(mag(faceFlux_))
-        );
+        )
+    );
 
 
     const surfaceScalarField& CDweights = mesh.surfaceInterpolation::weights();
@@ -294,23 +296,31 @@ Foam::tmp<Foam::surfaceScalarField> Foam::CICSAM::limiter
             const scalarField& pFaceFlux =
                 this->faceFlux_.boundaryField()[patchi];
 
-            scalarField pphiP =
-                phi.boundaryField()[patchi].patchInternalField();
+            scalarField pphiP
+            (
+                phi.boundaryField()[patchi].patchInternalField()
+            );
 
-            scalarField pphiN =
-                phi.boundaryField()[patchi].patchNeighbourField();
+            scalarField pphiN
+            (
+                phi.boundaryField()[patchi].patchNeighbourField()
+            );
 
-            vectorField pGradcP =
-                gradc.boundaryField()[patchi].patchInternalField();
+            vectorField pGradcP
+            (
+                gradc.boundaryField()[patchi].patchInternalField()
+            );
 
-            vectorField pGradcN =
-                gradc.boundaryField()[patchi].patchNeighbourField();
+            vectorField pGradcN
+            (
+                gradc.boundaryField()[patchi].patchNeighbourField()
+            );
 
             const scalarField& pCof = Cof.boundaryField()[patchi];
 
             // Build the d-vectors
             // Better version of d-vectors: Zeljko Tukovic, 25/Apr/2010
-            vectorField pd = bLim[patchi].patch().delta();
+            vectorField pd(bLim[patchi].patch().delta());
 
             forAll(pLim, faceI)
             {
@@ -351,14 +361,16 @@ Foam::tmp<Foam::surfaceScalarField> Foam::CICSAM::weights
     );
     surfaceScalarField& weightingFactors = tWeightingFactors();
 
-    volVectorField gradc = fvc::grad(phi);
+    volVectorField gradc(fvc::grad(phi));
 
-    surfaceScalarField Cof =
+    surfaceScalarField Cof
+    (
         mesh.time().deltaT()
        *upwind<scalar>(mesh, faceFlux_).interpolate
         (
             fvc::surfaceIntegrate(faceFlux_)
-        );
+        )
+    );
 
     const surfaceScalarField& CDweights = mesh.surfaceInterpolation::weights();
 
@@ -401,23 +413,31 @@ Foam::tmp<Foam::surfaceScalarField> Foam::CICSAM::weights
             const scalarField& pFaceFlux =
                 this->faceFlux_.boundaryField()[patchi];
 
-            scalarField pphiP =
-                phi.boundaryField()[patchi].patchInternalField();
+            scalarField pphiP
+            (
+                phi.boundaryField()[patchi].patchInternalField()
+            );
 
-            scalarField pphiN =
-                phi.boundaryField()[patchi].patchNeighbourField();
+            scalarField pphiN
+            (
+                phi.boundaryField()[patchi].patchNeighbourField()
+            );
 
-            vectorField pGradcP =
-                gradc.boundaryField()[patchi].patchInternalField();
+            vectorField pGradcP
+            (
+                gradc.boundaryField()[patchi].patchInternalField()
+            );
 
-            vectorField pGradcN =
-                gradc.boundaryField()[patchi].patchNeighbourField();
+            vectorField pGradcN
+            (
+                gradc.boundaryField()[patchi].patchNeighbourField()
+            );
 
             const scalarField& pCof = Cof.boundaryField()[patchi];
 
             // Build the d-vectors
             // Better version of d-vectors: Zeljko Tukovic, 25/Apr/2010
-            vectorField pd = bWeights[patchi].patch().delta();
+            vectorField pd(bWeights[patchi].patch().delta());
 
             forAll(pWeights, faceI)
             {

--- a/src/OpenFOAM-2.2.0/finiteVolume/interpolationSchemes/HRIC/HRIC.C
+++ b/src/OpenFOAM-2.2.0/finiteVolume/interpolationSchemes/HRIC/HRIC.C
@@ -278,14 +278,16 @@ Foam::tmp<Foam::surfaceScalarField> Foam::HRIC::limiter
     );
     surfaceScalarField& lim = tLimiter();
 
-    volVectorField gradc = fvc::grad(phi);
+    volVectorField gradc(fvc::grad(phi));
 
-    surfaceScalarField Cof =
+    surfaceScalarField Cof
+    (
         mesh.time().deltaT()
        *upwind<scalar>(mesh, faceFlux_).interpolate
         (
             fvc::surfaceIntegrate(faceFlux_)
-        );
+        )
+    );
 
     const surfaceScalarField& CDweights = mesh.surfaceInterpolation::weights();
 
@@ -327,23 +329,31 @@ Foam::tmp<Foam::surfaceScalarField> Foam::HRIC::limiter
             const scalarField& pFaceFlux =
                 this->faceFlux_.boundaryField()[patchi];
 
-            scalarField pphiP =
-                phi.boundaryField()[patchi].patchInternalField();
+            scalarField pphiP
+            (
+                phi.boundaryField()[patchi].patchInternalField()
+            );
 
-            scalarField pphiN =
-                phi.boundaryField()[patchi].patchNeighbourField();
+            scalarField pphiN
+            (
+                phi.boundaryField()[patchi].patchNeighbourField()
+            );
 
-            vectorField pGradcP =
-                gradc.boundaryField()[patchi].patchInternalField();
+            vectorField pGradcP
+            (
+                gradc.boundaryField()[patchi].patchInternalField()
+            );
 
-            vectorField pGradcN =
-                gradc.boundaryField()[patchi].patchNeighbourField();
+            vectorField pGradcN
+            (
+                gradc.boundaryField()[patchi].patchNeighbourField()
+            );
 
             const scalarField& pCof = Cof.boundaryField()[patchi];
 
             // Build the d-vectors
             // Better version of d-vectors: Zeljko Tukovic, 25/Apr/2010
-            vectorField pd = bLim[patchi].patch().delta();
+            vectorField pd(bLim[patchi].patch().delta());
 
             forAll(pLim, faceI)
             {
@@ -384,14 +394,16 @@ Foam::tmp<Foam::surfaceScalarField> Foam::HRIC::weights
     );
     surfaceScalarField& weightingFactors = tWeightingFactors();
 
-    volVectorField gradc = fvc::grad(phi);
+    volVectorField gradc(fvc::grad(phi));
 
-    surfaceScalarField Cof =
+    surfaceScalarField Cof
+    (
         mesh.time().deltaT()
        *upwind<scalar>(mesh, faceFlux_).interpolate
         (
             fvc::surfaceIntegrate(faceFlux_)
-        );
+        )
+    );
 
     const surfaceScalarField& CDweights = mesh.surfaceInterpolation::weights();
 
@@ -434,23 +446,31 @@ Foam::tmp<Foam::surfaceScalarField> Foam::HRIC::weights
             const scalarField& pFaceFlux =
                 this->faceFlux_.boundaryField()[patchi];
 
-            scalarField pphiP =
-                phi.boundaryField()[patchi].patchInternalField();
+            scalarField pphiP
+            (
+                phi.boundaryField()[patchi].patchInternalField()
+            );
 
-            scalarField pphiN =
-                phi.boundaryField()[patchi].patchNeighbourField();
+            scalarField pphiN
+            (
+                phi.boundaryField()[patchi].patchNeighbourField()
+            );
 
-            vectorField pGradcP =
-                gradc.boundaryField()[patchi].patchInternalField();
+            vectorField pGradcP
+            (
+                gradc.boundaryField()[patchi].patchInternalField()
+            );
 
-            vectorField pGradcN =
-                gradc.boundaryField()[patchi].patchNeighbourField();
+            vectorField pGradcN
+            (
+                gradc.boundaryField()[patchi].patchNeighbourField()
+            );
 
             const scalarField& pCof = Cof.boundaryField()[patchi];
 
             // Build the d-vectors
             // Better version of d-vectors: Zeljko Tukovic, 25/Apr/2010
-            vectorField pd = bWeights[patchi].patch().delta();
+            vectorField pd(bWeights[patchi].patch().delta());
 
             forAll(pWeights, faceI)
             {

--- a/src/OpenFOAM-2.2.0/finiteVolume/interpolationSchemes/mHRIC/mHRIC.C
+++ b/src/OpenFOAM-2.2.0/finiteVolume/interpolationSchemes/mHRIC/mHRIC.C
@@ -338,14 +338,16 @@ Foam::tmp<Foam::surfaceScalarField> Foam::mHRIC::limiter
     );
     surfaceScalarField& lim = tLimiter();
 
-    volVectorField gradc = fvc::grad(phi);
+    volVectorField gradc(fvc::grad(phi));
 
-    surfaceScalarField Cof =
+    surfaceScalarField Cof
+    (
         mesh.time().deltaT()
        *upwind<scalar>(mesh, faceFlux_).interpolate
         (
             fvc::surfaceIntegrate(faceFlux_)
-        );
+        )
+    );
 
     const surfaceScalarField& CDweights = mesh.surfaceInterpolation::weights();
 
@@ -387,23 +389,31 @@ Foam::tmp<Foam::surfaceScalarField> Foam::mHRIC::limiter
             const scalarField& pFaceFlux =
                 this->faceFlux_.boundaryField()[patchi];
 
-            scalarField pphiP =
-                phi.boundaryField()[patchi].patchInternalField();
+            scalarField pphiP
+            (
+                phi.boundaryField()[patchi].patchInternalField()
+            );
 
-            scalarField pphiN =
-                phi.boundaryField()[patchi].patchNeighbourField();
+            scalarField pphiN
+            (
+                phi.boundaryField()[patchi].patchNeighbourField()
+            );
 
-            vectorField pGradcP =
-                gradc.boundaryField()[patchi].patchInternalField();
+            vectorField pGradcP
+            (
+                gradc.boundaryField()[patchi].patchInternalField()
+            );
 
-            vectorField pGradcN =
-                gradc.boundaryField()[patchi].patchNeighbourField();
+            vectorField pGradcN
+            (
+                gradc.boundaryField()[patchi].patchNeighbourField()
+            );
 
             const scalarField& pCof = Cof.boundaryField()[patchi];
 
             // Build the d-vectors
             // Better version of d-vectors: Zeljko Tukovic, 25/Apr/2010
-            vectorField pd = bLim[patchi].patch().delta();
+            vectorField pd(bLim[patchi].patch().delta());
 
             forAll(pLim, faceI)
             {
@@ -444,14 +454,16 @@ Foam::tmp<Foam::surfaceScalarField> Foam::mHRIC::weights
     );
     surfaceScalarField& weightingFactors = tWeightingFactors();
 
-    volVectorField gradc = fvc::grad(phi);
+    volVectorField gradc(fvc::grad(phi));
 
-    surfaceScalarField Cof =
+    surfaceScalarField Cof
+    (
         mesh.time().deltaT()
        *upwind<scalar>(mesh, faceFlux_).interpolate
         (
             fvc::surfaceIntegrate(faceFlux_)
-        );
+        )
+    );
 
     const surfaceScalarField& CDweights = mesh.surfaceInterpolation::weights();
 
@@ -494,23 +506,31 @@ Foam::tmp<Foam::surfaceScalarField> Foam::mHRIC::weights
             const scalarField& pFaceFlux =
                 this->faceFlux_.boundaryField()[patchi];
 
-            scalarField pphiP =
-                phi.boundaryField()[patchi].patchInternalField();
+            scalarField pphiP
+            (
+                phi.boundaryField()[patchi].patchInternalField()
+            );
 
-            scalarField pphiN =
-                phi.boundaryField()[patchi].patchNeighbourField();
+            scalarField pphiN
+            (
+                phi.boundaryField()[patchi].patchNeighbourField()
+            );
 
-            vectorField pGradcP =
-                gradc.boundaryField()[patchi].patchInternalField();
+            vectorField pGradcP
+            (
+                gradc.boundaryField()[patchi].patchInternalField()
+            );
 
-            vectorField pGradcN =
-                gradc.boundaryField()[patchi].patchNeighbourField();
+            vectorField pGradcN
+            (
+                gradc.boundaryField()[patchi].patchNeighbourField()
+            );
 
             const scalarField& pCof = Cof.boundaryField()[patchi];
 
             // Build the d-vectors
             // Better version of d-vectors: Zeljko Tukovic, 25/Apr/2010
-            vectorField pd = bWeights[patchi].patch().delta();
+            vectorField pd(bWeights[patchi].patch().delta());
 
             forAll(pWeights, faceI)
             {

--- a/src/OpenFOAM-4.0/finiteVolume/interpolationSchemes/CICSAM/CICSAM.C
+++ b/src/OpenFOAM-4.0/finiteVolume/interpolationSchemes/CICSAM/CICSAM.C
@@ -236,7 +236,7 @@ Foam::tmp<Foam::surfaceScalarField> Foam::CICSAM::limiter
 //    surfaceScalarField& lim = tLimiter();
     surfaceScalarField& lim = tLimiter.ref();
 
-    volVectorField gradc = fvc::grad(phi);
+    volVectorField gradc(fvc::grad(phi));
 
 /*
     surfaceScalarField Cof =
@@ -247,12 +247,14 @@ Foam::tmp<Foam::surfaceScalarField> Foam::CICSAM::limiter
         );
 */
 
-    surfaceScalarField Cof =
+    surfaceScalarField Cof
+    (
         0.5 * mesh.time().deltaT()
         *upwind<scalar>(mesh, faceFlux_).interpolate
         (
             fvc::surfaceIntegrate(mag(faceFlux_))
-        );
+        )
+    );
 
 
     const surfaceScalarField& CDweights = mesh.surfaceInterpolation::weights();
@@ -296,23 +298,31 @@ Foam::tmp<Foam::surfaceScalarField> Foam::CICSAM::limiter
             const scalarField& pFaceFlux =
                 this->faceFlux_.boundaryField()[patchi];
 
-            scalarField pphiP =
-                phi.boundaryField()[patchi].patchInternalField();
+            scalarField pphiP
+            (
+                phi.boundaryField()[patchi].patchInternalField()
+            );
 
-            scalarField pphiN =
-                phi.boundaryField()[patchi].patchNeighbourField();
+            scalarField pphiN
+            (
+                phi.boundaryField()[patchi].patchNeighbourField()
+            );
 
-            vectorField pGradcP =
-                gradc.boundaryField()[patchi].patchInternalField();
+            vectorField pGradcP
+            (
+                gradc.boundaryField()[patchi].patchInternalField()
+            );
 
-            vectorField pGradcN =
-                gradc.boundaryField()[patchi].patchNeighbourField();
+            vectorField pGradcN
+            (
+                gradc.boundaryField()[patchi].patchNeighbourField()
+            );
 
             const scalarField& pCof = Cof.boundaryField()[patchi];
 
             // Build the d-vectors
             // Better version of d-vectors: Zeljko Tukovic, 25/Apr/2010
-            vectorField pd = bLim[patchi].patch().delta();
+            vectorField pd(bLim[patchi].patch().delta());
 
             forAll(pLim, faceI)
             {
@@ -353,14 +363,16 @@ Foam::tmp<Foam::surfaceScalarField> Foam::CICSAM::weights
     );
     surfaceScalarField& weightingFactors = tWeightingFactors.ref();
 
-    volVectorField gradc = fvc::grad(phi);
+    volVectorField gradc(fvc::grad(phi));
 
-    surfaceScalarField Cof =
+    surfaceScalarField Cof
+    (
         mesh.time().deltaT()
        *upwind<scalar>(mesh, faceFlux_).interpolate
         (
             fvc::surfaceIntegrate(faceFlux_)
-        );
+        )
+    );
 
     const surfaceScalarField& CDweights = mesh.surfaceInterpolation::weights();
 
@@ -403,23 +415,31 @@ Foam::tmp<Foam::surfaceScalarField> Foam::CICSAM::weights
             const scalarField& pFaceFlux =
                 this->faceFlux_.boundaryField()[patchi];
 
-            scalarField pphiP =
-                phi.boundaryField()[patchi].patchInternalField();
+            scalarField pphiP
+            (
+                phi.boundaryField()[patchi].patchInternalField()
+            );
 
-            scalarField pphiN =
-                phi.boundaryField()[patchi].patchNeighbourField();
+            scalarField pphiN
+            (
+                phi.boundaryField()[patchi].patchNeighbourField()
+            );
 
-            vectorField pGradcP =
-                gradc.boundaryField()[patchi].patchInternalField();
+            vectorField pGradcP
+            (
+                gradc.boundaryField()[patchi].patchInternalField()
+            );
 
-            vectorField pGradcN =
-                gradc.boundaryField()[patchi].patchNeighbourField();
+            vectorField pGradcN
+            (
+                gradc.boundaryField()[patchi].patchNeighbourField()
+            );
 
             const scalarField& pCof = Cof.boundaryField()[patchi];
 
             // Build the d-vectors
             // Better version of d-vectors: Zeljko Tukovic, 25/Apr/2010
-            vectorField pd = bWeights[patchi].patch().delta();
+            vectorField pd(bWeights[patchi].patch().delta());
 
             forAll(pWeights, faceI)
             {

--- a/src/OpenFOAM-4.0/finiteVolume/interpolationSchemes/HRIC/HRIC.C
+++ b/src/OpenFOAM-4.0/finiteVolume/interpolationSchemes/HRIC/HRIC.C
@@ -278,14 +278,16 @@ Foam::tmp<Foam::surfaceScalarField> Foam::HRIC::limiter
     );
     surfaceScalarField& lim = tLimiter.ref();
 
-    volVectorField gradc = fvc::grad(phi);
+    volVectorField gradc(fvc::grad(phi));
 
-    surfaceScalarField Cof =
+    surfaceScalarField Cof
+    (
         mesh.time().deltaT()
        *upwind<scalar>(mesh, faceFlux_).interpolate
         (
             fvc::surfaceIntegrate(faceFlux_)
-        );
+        )
+    );
 
     const surfaceScalarField& CDweights = mesh.surfaceInterpolation::weights();
 
@@ -328,23 +330,31 @@ Foam::tmp<Foam::surfaceScalarField> Foam::HRIC::limiter
             const scalarField& pFaceFlux =
                 this->faceFlux_.boundaryField()[patchi];
 
-            scalarField pphiP =
-                phi.boundaryField()[patchi].patchInternalField();
+            scalarField pphiP
+            (
+                phi.boundaryField()[patchi].patchInternalField()
+            );
 
-            scalarField pphiN =
-                phi.boundaryField()[patchi].patchNeighbourField();
+            scalarField pphiN
+            (
+                phi.boundaryField()[patchi].patchNeighbourField()
+            );
 
-            vectorField pGradcP =
-                gradc.boundaryField()[patchi].patchInternalField();
+            vectorField pGradcP
+            (
+                gradc.boundaryField()[patchi].patchInternalField()
+            );
 
-            vectorField pGradcN =
-                gradc.boundaryField()[patchi].patchNeighbourField();
+            vectorField pGradcN
+            (
+                gradc.boundaryField()[patchi].patchNeighbourField()
+            );
 
             const scalarField& pCof = Cof.boundaryField()[patchi];
 
             // Build the d-vectors
             // Better version of d-vectors: Zeljko Tukovic, 25/Apr/2010
-            vectorField pd = bLim[patchi].patch().delta();
+            vectorField pd(bLim[patchi].patch().delta());
 
             forAll(pLim, faceI)
             {
@@ -385,14 +395,16 @@ Foam::tmp<Foam::surfaceScalarField> Foam::HRIC::weights
     );
     surfaceScalarField& weightingFactors = tWeightingFactors.ref();
 
-    volVectorField gradc = fvc::grad(phi);
+    volVectorField gradc(fvc::grad(phi));
 
-    surfaceScalarField Cof =
+    surfaceScalarField Cof
+    (
         mesh.time().deltaT()
        *upwind<scalar>(mesh, faceFlux_).interpolate
         (
             fvc::surfaceIntegrate(faceFlux_)
-        );
+        )
+    );
 
     const surfaceScalarField& CDweights = mesh.surfaceInterpolation::weights();
 
@@ -435,23 +447,31 @@ Foam::tmp<Foam::surfaceScalarField> Foam::HRIC::weights
             const scalarField& pFaceFlux =
                 this->faceFlux_.boundaryField()[patchi];
 
-            scalarField pphiP =
-                phi.boundaryField()[patchi].patchInternalField();
+            scalarField pphiP
+            (
+                phi.boundaryField()[patchi].patchInternalField()
+            );
 
-            scalarField pphiN =
-                phi.boundaryField()[patchi].patchNeighbourField();
+            scalarField pphiN
+            (
+                phi.boundaryField()[patchi].patchNeighbourField()
+            );
 
-            vectorField pGradcP =
-                gradc.boundaryField()[patchi].patchInternalField();
+            vectorField pGradcP
+            (
+                gradc.boundaryField()[patchi].patchInternalField()
+            );
 
-            vectorField pGradcN =
-                gradc.boundaryField()[patchi].patchNeighbourField();
+            vectorField pGradcN
+            (
+                gradc.boundaryField()[patchi].patchNeighbourField()
+            );
 
             const scalarField& pCof = Cof.boundaryField()[patchi];
 
             // Build the d-vectors
             // Better version of d-vectors: Zeljko Tukovic, 25/Apr/2010
-            vectorField pd = bWeights[patchi].patch().delta();
+            vectorField pd(bWeights[patchi].patch().delta());
 
             forAll(pWeights, faceI)
             {

--- a/src/OpenFOAM-4.0/finiteVolume/interpolationSchemes/mHRIC/mHRIC.C
+++ b/src/OpenFOAM-4.0/finiteVolume/interpolationSchemes/mHRIC/mHRIC.C
@@ -338,14 +338,16 @@ Foam::tmp<Foam::surfaceScalarField> Foam::mHRIC::limiter
     );
     surfaceScalarField& lim = tLimiter.ref();
 
-    volVectorField gradc = fvc::grad(phi);
+    volVectorField gradc(fvc::grad(phi));
 
-    surfaceScalarField Cof =
+    surfaceScalarField Cof
+    (
         mesh.time().deltaT()
        *upwind<scalar>(mesh, faceFlux_).interpolate
         (
             fvc::surfaceIntegrate(faceFlux_)
-        );
+        )
+    );
 
     const surfaceScalarField& CDweights = mesh.surfaceInterpolation::weights();
 
@@ -387,23 +389,31 @@ Foam::tmp<Foam::surfaceScalarField> Foam::mHRIC::limiter
             const scalarField& pFaceFlux =
                 this->faceFlux_.boundaryField()[patchi];
 
-            scalarField pphiP =
-                phi.boundaryField()[patchi].patchInternalField();
+            scalarField pphiP
+            (
+                phi.boundaryField()[patchi].patchInternalField()
+            );
 
-            scalarField pphiN =
-                phi.boundaryField()[patchi].patchNeighbourField();
+            scalarField pphiN
+            (
+                phi.boundaryField()[patchi].patchNeighbourField()
+            );
 
-            vectorField pGradcP =
-                gradc.boundaryField()[patchi].patchInternalField();
+            vectorField pGradcP
+            (
+                gradc.boundaryField()[patchi].patchInternalField()
+            );
 
-            vectorField pGradcN =
-                gradc.boundaryField()[patchi].patchNeighbourField();
+            vectorField pGradcN
+            (
+                gradc.boundaryField()[patchi].patchNeighbourField()
+            );
 
             const scalarField& pCof = Cof.boundaryField()[patchi];
 
             // Build the d-vectors
             // Better version of d-vectors: Zeljko Tukovic, 25/Apr/2010
-            vectorField pd = bLim[patchi].patch().delta();
+            vectorField pd(bLim[patchi].patch().delta());
 
             forAll(pLim, faceI)
             {
@@ -444,14 +454,16 @@ Foam::tmp<Foam::surfaceScalarField> Foam::mHRIC::weights
     );
     surfaceScalarField& weightingFactors = tWeightingFactors.ref();
 
-    volVectorField gradc = fvc::grad(phi);
+    volVectorField gradc(fvc::grad(phi));
 
-    surfaceScalarField Cof =
+    surfaceScalarField Cof
+    (
         mesh.time().deltaT()
        *upwind<scalar>(mesh, faceFlux_).interpolate
         (
             fvc::surfaceIntegrate(faceFlux_)
-        );
+        )
+    );
 
     const surfaceScalarField& CDweights = mesh.surfaceInterpolation::weights();
 
@@ -494,23 +506,31 @@ Foam::tmp<Foam::surfaceScalarField> Foam::mHRIC::weights
             const scalarField& pFaceFlux =
                 this->faceFlux_.boundaryField()[patchi];
 
-            scalarField pphiP =
-                phi.boundaryField()[patchi].patchInternalField();
+            scalarField pphiP
+            (
+                phi.boundaryField()[patchi].patchInternalField()
+            );
 
-            scalarField pphiN =
-                phi.boundaryField()[patchi].patchNeighbourField();
+            scalarField pphiN
+            (
+                phi.boundaryField()[patchi].patchNeighbourField()
+            );
 
-            vectorField pGradcP =
-                gradc.boundaryField()[patchi].patchInternalField();
+            vectorField pGradcP
+            (
+                gradc.boundaryField()[patchi].patchInternalField()
+            );
 
-            vectorField pGradcN =
-                gradc.boundaryField()[patchi].patchNeighbourField();
+            vectorField pGradcN
+            (
+                gradc.boundaryField()[patchi].patchNeighbourField()
+            );
 
             const scalarField& pCof = Cof.boundaryField()[patchi];
 
             // Build the d-vectors
             // Better version of d-vectors: Zeljko Tukovic, 25/Apr/2010
-            vectorField pd = bWeights[patchi].patch().delta();
+            vectorField pd(bWeights[patchi].patch().delta());
 
             forAll(pWeights, faceI)
             {

--- a/src/OpenFOAM-4.0/isoAdvection/isoAdvection.C
+++ b/src/OpenFOAM-4.0/isoAdvection/isoAdvection.C
@@ -95,7 +95,7 @@ Foam::isoAdvection::isoAdvection
     //Prepare lists used in parallel runs
     if (Pstream::parRun())
     {
-        //Force calculation of cell centres and volumes (else parallel 
+        //Force calculation of cell centres and volumes (else parallel
         //communication may crash)
         mesh_.C();
 
@@ -132,7 +132,7 @@ void Foam::isoAdvection::timeIntegratedFlux()
     // Create interpolation object for interpolating velocity to iso face
     // centres
     interpolationCellPoint<vector> UInterp(U_);
-    
+
     //For each downwind face of each surface cell we "isoadvect" to find dVf
     label nSurfaceCells = 0;
 
@@ -140,7 +140,7 @@ void Foam::isoAdvection::timeIntegratedFlux()
     // whether cells could possibly need bounding
     clearIsoFaceData();
     checkBounding_ = false;
-    
+
     // Get necessary references
     const scalarField& phiIn = phi_.internalField();
     const scalarField& magSfIn = mesh_.magSf().internalField();
@@ -163,11 +163,11 @@ void Foam::isoAdvection::timeIntegratedFlux()
             nSurfaceCells++;
             surfCells_.append(cellI);
             checkBounding_[cellI] = true;
-            
+
             isoDebug
             (
-                Info << "\n------------ Cell " << cellI << " with alpha1 = " 
-                    << alpha1In_[cellI] << " and 1-alpha1 = " 
+                Info << "\n------------ Cell " << cellI << " with alpha1 = "
+                    << alpha1In_[cellI] << " and 1-alpha1 = "
                     << 1.0-alpha1In_[cellI] << " ------------"
                     << endl;
             )
@@ -179,9 +179,9 @@ void Foam::isoAdvection::timeIntegratedFlux()
             // cell is cut, 1: cell is fully above the isosurface)
             label cellStatus = isoCutCell_.vofCutCell
             (
-                cellI, 
-                alpha1In_[cellI], 
-                vof2IsoTol_, 
+                cellI,
+                alpha1In_[cellI],
+                vof2IsoTol_,
                 maxIter
             );
 
@@ -193,18 +193,18 @@ void Foam::isoAdvection::timeIntegratedFlux()
                 const scalar f0 = isoCutCell_.isoValue();
                 const point x0 = isoCutCell_.isoFaceCentre();
                 vector n0 = isoCutCell_.isoFaceArea();
-                            
-                //If cell almost full or empty isoFace may be undefined. 
+
+                //If cell almost full or empty isoFace may be undefined.
                 //Calculating normal by going a little into the cell.
                 // Note: put 1e-6 into the tolerance
-                if ( mag(n0) < 1e-6*minMagSf_ ) 
+                if ( mag(n0) < 1e-6*minMagSf_ )
                 {
                     WarningIn
                     (
                         "void Foam::isoAdvection::timeIntegratedFlux()"
                     ) << "mag(n0) = " << mag(n0)
                       << " < 1e-6*minMagSf_ for cell " << cellI << endl;
-                      
+
                     // Initialise minimum and maximum values
                     scalar fMin = GREAT;
                     scalar fMax = -GREAT;
@@ -221,9 +221,9 @@ void Foam::isoAdvection::timeIntegratedFlux()
                         // Note: make a tolerance
                         fInside =  fMin + 1e-3*(fMax-fMin);
                     }
-                    else 
+                    else
                     {
-                        fInside =  fMax - 1e-3*(fMax-fMin);                        
+                        fInside =  fMax - 1e-3*(fMax-fMin);
                     }
 
 //                    scalar fInside = f0 + sign(alpha1In_[cellI]-0.5)*1e-3;
@@ -232,8 +232,8 @@ void Foam::isoAdvection::timeIntegratedFlux()
                     // area vector
                     isoCutCell_.calcSubCell(cellI,fInside);
                     n0 = isoCutCell_.isoFaceArea();
-                }    
-                
+                }
+
                 if ( mag(n0) > 1e-6*minMagSf_ )
                 {
                     isoDebug(Info << "Normalising n0: " << n0 << endl;)
@@ -262,34 +262,34 @@ void Foam::isoAdvection::timeIntegratedFlux()
 
                 isoDebug
                 (
-                    Info << "calcIsoFace gives initial surface: \nx0 = " << x0 
-                        << ", \nn0 = " << n0 << ", \nf0 = " << f0 << ", \nUn0 = " 
+                    Info << "calcIsoFace gives initial surface: \nx0 = " << x0
+                        << ", \nn0 = " << n0 << ", \nf0 = " << f0 << ", \nUn0 = "
                         << Un0 << endl;
                 )
 
-                //Estimating time integrated water flux through each downwind 
+                //Estimating time integrated water flux through each downwind
                 //face
                 const cell& cellFaces = meshCells[cellI];
                 forAll (cellFaces, fi)
                 {
                     // Get current face index
                     const label faceI = cellFaces[fi];
-                    
+
                     // Check if the face is internal face
                     if (mesh_.isInternalFace(faceI))
                     {
                         bool isDownwindFace = false;
                         label otherCell = -1;
-                        
+
                         // Check if the cell is owner
                         if (cellI == own[faceI])
                         {
-                            
+
                             if (phiIn[faceI] > 10*SMALL)
                             {
                                 isDownwindFace = true;
                             }
-                            
+
                             // Other cell is neighbour
                             otherCell = nei[faceI];
                         }
@@ -308,25 +308,25 @@ void Foam::isoAdvection::timeIntegratedFlux()
                         // face
                         if (isDownwindFace)
                         {
-//                        Info << "Setting value for internal face " << faceI 
+//                        Info << "Setting value for internal face " << faceI
 //                          << endl;
                             dVfIn[faceI] = timeIntegratedFlux
                             (
-                                faceI, 
-                                x0, 
-                                n0, 
+                                faceI,
+                                x0,
+                                n0,
                                 Un0,
-                                f0, 
-                                dt, 
-                                phiIn[faceI], 
+                                f0,
+                                dt,
+                                phiIn[faceI],
                                 magSfIn[faceI]
                             );
                         }
 
-                        //We want to check bounding of neighbour cells to surface 
+                        //We want to check bounding of neighbour cells to surface
                         //cells as well:
                         checkBounding_[otherCell] = true;
-                        
+
                         // Also check neighbours of neighbours.
                         // Note: consider making it a run time selectable
                         // extension level (easily done with recursion):
@@ -353,7 +353,7 @@ void Foam::isoAdvection::timeIntegratedFlux()
             }
         }
     }
-    
+
      // Get references to boundary fields
 /*    const surfaceScalarField::GeometricBoundaryField& phib =
         phi_.boundaryField();
@@ -411,13 +411,13 @@ void Foam::isoAdvection::timeIntegratedFlux()
             }
         }
     }
-   
+
     // Print out number of surface cells
     Info<< "Number of isoAdvector surface cells = "
         << returnReduce(nSurfaceCells, sumOp<label>()) << endl;
 }
 
-    
+
 Foam::scalar Foam::isoAdvection::timeIntegratedFlux
 (
     const label fLabel,
@@ -440,7 +440,7 @@ Foam::scalar Foam::isoAdvection::timeIntegratedFlux
     {
         scalar alphaf = 0.0;
         scalar waterInUpwindCell = 0.0;
-        
+
         if ( phi > 0  || !mesh_.isInternalFace(fLabel) )
         {
             label upwindCell = mesh_.owner()[fLabel];
@@ -453,7 +453,7 @@ Foam::scalar Foam::isoAdvection::timeIntegratedFlux
             alphaf = alpha1In_[upwindCell];
             waterInUpwindCell = alphaf*mesh_.V()[upwindCell];
         }
-        
+
         isoDebug
         (
             WarningIn
@@ -468,9 +468,9 @@ Foam::scalar Foam::isoAdvection::timeIntegratedFlux
     }
 
 
-    //Find sorted list of times where the isoFace will arrive at face points 
+    //Find sorted list of times where the isoFace will arrive at face points
     //given initial position x0 and velocity Un0*n0
-    
+
     // Get points for this face
     const labelList& pLabels = mesh_.faces()[fLabel];
     const label nPoints = pLabels.size();
@@ -487,9 +487,9 @@ Foam::scalar Foam::isoAdvection::timeIntegratedFlux
         // distance to the initial surface and the surface normal velocity
 
         pTimes = ((fPts - x0) & n0)/Un0;
-        
+
         scalar dVf = 0;
-        
+
         //Check if pTimes changes direction more than twice when looping face
         label nShifts = 0;
         forAll(pTimes, pi)
@@ -524,8 +524,8 @@ Foam::scalar Foam::isoAdvection::timeIntegratedFlux
 //            WarningIn
 //            (
 //                "Foam::scalar Foam::isoAdvection::timeIntegratedFlux(...)"
-//            )   << "Warning: nShifts = " << nShifts << " on face " << fLabel 
-//                << " owned by cell " << mesh_.owner()[fLabel] << endl;            
+//            )   << "Warning: nShifts = " << nShifts << " on face " << fLabel
+//                << " owned by cell " << mesh_.owner()[fLabel] << endl;
         }
         else
         {
@@ -533,7 +533,7 @@ Foam::scalar Foam::isoAdvection::timeIntegratedFlux
             (
                 "Foam::scalar Foam::isoAdvection::timeIntegratedFlux(...)"
             )   << "Warning: nShifts = " << nShifts << " on face " << fLabel
-                << " with pTimes = " << pTimes << " owned by cell " 
+                << " with pTimes = " << pTimes << " owned by cell "
                 << mesh_.owner()[fLabel] << endl;
         }
 
@@ -555,7 +555,7 @@ Foam::scalar Foam::isoAdvection::timeIntegratedFlux
               << " using subFaceFraction giving alphaf = " << alphaf
               << endl;
         )
-        
+
         return phi*dt*alphaf;
     }
 }
@@ -578,31 +578,31 @@ Foam::scalar Foam::isoAdvection::timeIntegratedArea
     //Sorting face vertex encounter time list
     scalarList sortedTimes(pTimes);
     sort(sortedTimes);
-    
+
     isoDebug(Info << "sortedTimes = " << sortedTimes << endl;)
 
-    //Dealing with case where face is not cut by surface during time interval 
+    //Dealing with case where face is not cut by surface during time interval
     //[0,dt] because face was already passed by surface
     if ( sortedTimes.last() <= 0.0 )
     {
         //All cuttings in the past
         isoDebug(Info << "All cuttings in the past" << endl;)
-        
+
         tIntArea = magSf*dt*pos(Un0); //If all face cuttings were in the past and cell is filling up (Un0>0) then face must be full during whole time interval
         return tIntArea;
     }
 
-    //Dealing with case where face is not cut by surface during time interval 
+    //Dealing with case where face is not cut by surface during time interval
     //[0,dt] because dt is too small for surface to reach closest face point
     if ( sortedTimes.first() >= dt )
     {
         //All cuttings in the future
         isoDebug(Info << "All cuttings in the future" << endl;)
-        
-        //If all cuttings are in the future but non of them within [0,dt] then 
-        //if cell is filling up (Un0 > 0) face must be empty during whole time 
-        //interval        
-        tIntArea = magSf*dt*(1-pos(Un0)); 
+
+        //If all cuttings are in the future but non of them within [0,dt] then
+        //if cell is filling up (Un0 > 0) face must be empty during whole time
+        //interval
+        tIntArea = magSf*dt*(1-pos(Un0));
         return tIntArea;
     }
 
@@ -624,10 +624,10 @@ Foam::scalar Foam::isoAdvection::timeIntegratedArea
             t.append(curTime);
         }
     }
-    
+
     // Finally append time step
     t.append(dt);
-    
+
     isoDebug(Info << "Cutting sortedTimes at 0 and dt: t = " << t << endl;)
 
 //    Info << "times = " << t << endl;
@@ -636,7 +636,7 @@ Foam::scalar Foam::isoAdvection::timeIntegratedArea
     bool faceUncutInFirstInterval(sortedTimes.first() > 0.0);
     bool faceUncutInLastInterval(sortedTimes.last() < dt);
 
-    //Dealing with cases where face is cut at least once during time interval 
+    //Dealing with cases where face is cut at least once during time interval
     //[0,dt]
     label nt = 0; //sub time interval counter
     scalar initialArea = 0.0; //Submerged area at time
@@ -644,7 +644,7 @@ Foam::scalar Foam::isoAdvection::timeIntegratedArea
     //Special treatment for first time interval if face is uncut during this
     if ( faceUncutInFirstInterval )
     {
-        //If Un0 > 0 cell is filling up - hence if face is cut at a later time 
+        //If Un0 > 0 cell is filling up - hence if face is cut at a later time
         //but not initially it must be initially empty
         tIntArea = magSf*(t[nt+1]-t[nt])*(1.0-pos(Un0));
         initialArea = magSf*(1.0-pos(Un0));
@@ -663,7 +663,7 @@ Foam::scalar Foam::isoAdvection::timeIntegratedArea
             Info<< "face is initially cut, so finding initial area, pTimes = "
                 << pTimes << ", Un0 = " << Un0 << endl;
         )
-        
+
         isoCutFace_.calcSubFace(fPts,-sign(Un0)*pTimes, 0.0);
         initialArea = mag(isoCutFace_.subFaceArea());
     }
@@ -679,14 +679,14 @@ Foam::scalar Foam::isoAdvection::timeIntegratedArea
         // Note: please think of grouping some of the lines in logical fashion
         DynamicList<point> cutPoints1(3), cutPoints2(3);
         isoCutFace_.cutPoints(fPts, pTimes, t[nt], cutPoints1);
-        isoCutFace_.cutPoints(fPts, pTimes, t[nt+1], cutPoints2);        
+        isoCutFace_.cutPoints(fPts, pTimes, t[nt+1], cutPoints2);
         scalar quadArea, intQuadArea;
         quadAreaCoeffs(cutPoints1, cutPoints2, quadArea, intQuadArea);
         //Integration of area(t) = A*t^2+B*t from t = 0 to 1.
         scalar integratedQuadArea = sign(Un0)*intQuadArea;
         tIntArea += (t[nt+1]-t[nt])*(initialArea + integratedQuadArea);
         //Adding quad area to submerged area
-        initialArea += sign(Un0)*quadArea; 
+        initialArea += sign(Un0)*quadArea;
 
         isoDebug
         (
@@ -710,7 +710,7 @@ Foam::scalar Foam::isoAdvection::timeIntegratedArea
         // interval.
         tIntArea += magSf*(t[nt + 1] - t[nt])*pos(Un0);
     }
-    
+
     return tIntArea;
 }
 
@@ -725,7 +725,7 @@ void Foam::isoAdvection::getDownwindFaces
     // as arguments
 
     isoDebug(Info << "Enter getDownwindFaces " << endl;)
-    
+
     // Get necessary mesh data and cell information
     const unallocLabelList& own = mesh_.owner();
     const cellList& cells = mesh_.cells();
@@ -822,14 +822,14 @@ void Foam::isoAdvection::quadAreaCoeffs
                 ) << "Vertex face was cut at pf1 = " << pf1 << endl;
             }
         }
-        
+
         //Defining local coordinates for area integral calculation
         vector xhat = B - A;
         xhat /= mag(xhat);
         vector yhat = (D-A);
         yhat -= ((yhat & xhat)*xhat);
         yhat /= mag(yhat);
-        
+
 //        isoDebug
 //        (
 //            Info<< "xhat = " << xhat << ", yhat = " << yhat << ", zhat = "
@@ -849,7 +849,7 @@ void Foam::isoAdvection::quadAreaCoeffs
             C = tmp;
         }
 
-//        Info << "A = " << A << ", B = " << B << ", C = " << C << ", D = " 
+//        Info << "A = " << A << ", B = " << B << ", C = " << C << ", D = "
 //          << D << endl;
         scalar Bx = mag(B-A);
         scalar Cx = (C-A) & xhat;
@@ -921,65 +921,65 @@ void Foam::isoAdvection::limitFluxes
     label nUndershoots = 20;//sum(neg(alphaNew+aTol));
     label nOvershoots = 20;//sum(pos(alphaNew-1-aTol));
     cellIsBounded_ = false;
-    
+
     // Loop number of bounding steps
     for (label n = 0; n < nAlphaBounds_; n++)
     {
-        Info << "Running bounding number " << n + 1 << " of time " 
+        Info << "Running bounding number " << n + 1 << " of time "
             << mesh_.time().value() << endl;
 
         if ( maxAlphaMinus1 > aTol ) // Note: tolerances
         {
             isoDebug(Info << "Bound from above... " << endl;)
-            
+
 //          scalarField dVfcorrected = dVf_.internalField();
 
             surfaceScalarField dVfcorrected("dVfcorrected", dVf_);
             DynamicList<label> correctedFaces(3*nOvershoots);
             boundFromAbove(alpha1In_,dVfcorrected,correctedFaces);
-            
+
             forAll(correctedFaces,fi)
             {
                 label fLabel = correctedFaces[fi];
-                
+
                 //Change to treat boundaries consistently
                 faceValue(dVf_, fLabel, faceValue(dVfcorrected, fLabel));
             }
-            
+
             syncProcPatches(dVf_, phi_);
         }
 
         if ( minAlpha < -aTol ) // Note: tolerances
         {
             isoDebug(Info << "Bound from below... " << endl;)
-            
-            scalarField alpha2 = 1.0 - alpha1In_;
+
+            scalarField alpha2(1.0 - alpha1In_);
             surfaceScalarField dVfcorrected
             (
-                "dVfcorrected", 
+                "dVfcorrected",
                 phi_*dimensionedScalar("dt", dimTime, dt) - dVf_
             );
-//          dVfcorrected -= dVf_;   // phi_ and dVf_ have same sign and dVf_ is 
+//          dVfcorrected -= dVf_;   // phi_ and dVf_ have same sign and dVf_ is
                                     // the portion of phi_*dt that is water.
-            // If phi_ > 0 then dVf_ > 0 and mag(phi_*dt-dVf_) < mag(phi_*dt) as 
+            // If phi_ > 0 then dVf_ > 0 and mag(phi_*dt-dVf_) < mag(phi_*dt) as
             // it should.
-            // If phi_ < 0 then dVf_ < 0 and mag(phi_*dt-dVf_) < mag(phi_*dt) as 
+            // If phi_ < 0 then dVf_ < 0 and mag(phi_*dt-dVf_) < mag(phi_*dt) as
             // it should.
             DynamicList<label> correctedFaces(3*nUndershoots);
             boundFromAbove(alpha2,dVfcorrected,correctedFaces);
             forAll(correctedFaces,fi)
             {
                 label fLabel = correctedFaces[fi];
-                
+
                 //Change to treat boundaries consistently
                 scalar phi = faceValue(phi_,fLabel);
                 scalar dVcorr = faceValue(dVfcorrected,fLabel);
                 faceValue(dVf_, fLabel, phi*dt - dVcorr);
             }
-            
+
             syncProcPatches(dVf_, phi_);
         }
-        
+
 //        //Check if still unbounded
 //        alphaNew = alpha1In_ - fvc::surfaceIntegrate(dVf);
 //        maxAlphaMinus1 = max(alphaNew-1);
@@ -1025,7 +1025,7 @@ void Foam::isoAdvection::boundFromAbove
             label nFacesToPassFluidThrough = 1;
 
             bool firstLoop = true;
-            // First try to pass surplus fluid on to neighbour cells that are 
+            // First try to pass surplus fluid on to neighbour cells that are
             // not filled and to which dVf < phi*dt
             while ( alphaOvershoot > aTol && nFacesToPassFluidThrough > 0 )
             {
@@ -1058,11 +1058,11 @@ void Foam::isoAdvection::boundFromAbove
                     const scalar dVff = faceValue(dVf,fLabel);
                     maxExtraFaceFluidTrans = mag(phif*dt - dVff);
 
-                    // dVf has same sign as phi and so if phi>0 we have 
+                    // dVf has same sign as phi and so if phi>0 we have
                     // mag(phi_[fLabel]*dt) - mag(dVf[fLabel]) = phi_[fLabel]*dt
                     // - dVf[fLabel]
-                    // If phi < 0 we have mag(phi_[fLabel]*dt) - 
-                    // mag(dVf[fLabel]) = -phi_[fLabel]*dt - (-dVf[fLabel]) > 0 
+                    // If phi < 0 we have mag(phi_[fLabel]*dt) -
+                    // mag(dVf[fLabel]) = -phi_[fLabel]*dt - (-dVf[fLabel]) > 0
                     // since mag(dVf) < phi*dt
                     isoDebug
                     (
@@ -1097,13 +1097,13 @@ void Foam::isoAdvection::boundFromAbove
                     const label fLabel = facesToPassFluidThrough[fi];
                     scalar fluidToPassThroughFace = fluidToPassOn*
                         mag(phi[fi]*dt)/dVftot;
-                    
-                    nFacesToPassFluidThrough += 
+
+                    nFacesToPassFluidThrough +=
                         pos(dVfmax[fi] - fluidToPassThroughFace);
-                    
-                    fluidToPassThroughFace = 
+
+                    fluidToPassThroughFace =
                         min(fluidToPassThroughFace,dVfmax[fi]);
-                    
+
                     scalar dVff = faceValue(dVf, fLabel);
                     dVff += sign(phi[fi])*fluidToPassThroughFace;
                     faceValue(dVf, fLabel, dVff);
@@ -1114,7 +1114,7 @@ void Foam::isoAdvection::boundFromAbove
                         correctedFaces.append(fLabel);
                     }
                 }
-                
+
                 firstLoop = false;
                 alpha1New = alpha1[cellI] - netFlux(dVf, cellI)/Vi;
                 alphaOvershoot = alpha1New - 1.0;
@@ -1128,7 +1128,7 @@ void Foam::isoAdvection::boundFromAbove
             }
         }
     }
-    
+
     isoDebug(Info << "correctedFaces = " << correctedFaces << endl;)
 }
 
@@ -1315,7 +1315,7 @@ void Foam::isoAdvection::advect()
     //Interpolating alpha1 cell centre values to mesh points (vertices)
     ap_ = vpi_.interpolate(alpha1_.oldTime());
 
-    //Initialising dVf with upwind values, i.e. phi[fLabel]*alpha1[upwindCell]*dt    
+    //Initialising dVf with upwind values, i.e. phi[fLabel]*alpha1[upwindCell]*dt
     dVf_ = upwind<scalar>(mesh_, phi_).flux(alpha1_.oldTime())*
         mesh_.time().deltaT();
 
@@ -1327,7 +1327,7 @@ void Foam::isoAdvection::advect()
 
     //Adjust dVf for unbounded cells
     limitFluxes();
-    
+
     // Advect the free surface
     alpha1_ = alpha1_.oldTime() - fvc::surfaceIntegrate(dVf_);
     alpha1_.correctBoundaryConditions();


### PR DESCRIPTION
1. Changed assignment constructor from tmp<T>, which is ambiguous, to explicit constructor from tmp<T>.
2. Introduced workaround for API change between 2.2.0 and 2.2.1. This time it should work with both versions.
3. More portable sed expressions in Allrun scripts (tested on OS X and Linux).

Build was tested on OS X with Apple's clang 8.0.0.

Build was tested with OpenFOAM 2.2.x and 4.x.

Simulation results for damBreak are similar but not exactly the same (between 2.2.x and 4.x):

- 2.2.x / 0.3 s
  ![2 2 x-0 3s](https://cloud.githubusercontent.com/assets/322635/21156016/9b131d84-c174-11e6-954e-7e5dbe6be466.png)
- 4.x / 0.3 s
  ![4 x-0 3s](https://cloud.githubusercontent.com/assets/322635/21156043/b16ad158-c174-11e6-9b72-2e88cf587676.png)
- 2.2.x / 1 s
  ![2 2 x-1s](https://cloud.githubusercontent.com/assets/322635/21156051/baad55e2-c174-11e6-8c97-761667a9f026.png)
- 4.x / 1 s
  ![4 x-1s](https://cloud.githubusercontent.com/assets/322635/21156058/c20bac9e-c174-11e6-8bef-7ea181b4e481.png)
- 2.2.x / 2 s
  ![2 2 x-2s](https://cloud.githubusercontent.com/assets/322635/21156071/cb65bf0a-c174-11e6-8579-63d15b97a133.png)
- 4.x / 2 s
  ![4 x-2s](https://cloud.githubusercontent.com/assets/322635/21156098/de0ead6a-c174-11e6-8545-5abf17194aca.png)

Yet I think it is a result of differences between 2.2.x and 4.x rather than the result of different way of field construction.