### PR TITLE
Update calcAdvectErrors.C for compatibility with OpenFOAM-dev

### DIFF
--- a/OpenFOAM/applications/utilities/postProcessing/calcAdvectErrors/calcAdvectErrors.C
+++ b/OpenFOAM/applications/utilities/postProcessing/calcAdvectErrors/calcAdvectErrors.C
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
 {
     timeSelector::addOptions();
 
-    Foam::argList::noBanner();
+    Foam::argList::noParallel();
     #include "setRootCase.H"
 
     // Reading user specified time(s)


### PR DESCRIPTION
In the dev version of OpenFOAM noBanner is changed to noParallel. So it might be useful if a dev version is also be added with this change. I compiled it with this change and it worked.